### PR TITLE
[PR] The proj files have been updated to enable SourceLink

### DIFF
--- a/Source/AccidentalFish.Foundations.Policies/AccidentalFish.Foundations.Policies.csproj
+++ b/Source/AccidentalFish.Foundations.Policies/AccidentalFish.Foundations.Policies.csproj
@@ -16,7 +16,15 @@
     <Version>2.0.0</Version>
     <AssemblyVersion>2.0.0.0</AssemblyVersion>
     <FileVersion>2.0.0.0</FileVersion>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
+  </ItemGroup>
+
 
   <ItemGroup>
     <PackageReference Include="AccidentalFish.DependencyResolver" Version="1.0.0" />

--- a/Source/AccidentalFish.Foundations.Resources.Abstractions/AccidentalFish.Foundations.Resources.Abstractions.csproj
+++ b/Source/AccidentalFish.Foundations.Resources.Abstractions/AccidentalFish.Foundations.Resources.Abstractions.csproj
@@ -15,7 +15,15 @@
     <Version>2.0.0</Version>
     <AssemblyVersion>2.0.0.0</AssemblyVersion>
     <FileVersion>2.0.0.0</FileVersion>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
+  </ItemGroup>
+
 
   <ItemGroup>
     <PackageReference Include="AccidentalFish.DependencyResolver" Version="1.0.0" />

--- a/Source/AccidentalFish.Foundations.Resources.Azure/AccidentalFish.Foundations.Resources.Azure.csproj
+++ b/Source/AccidentalFish.Foundations.Resources.Azure/AccidentalFish.Foundations.Resources.Azure.csproj
@@ -15,7 +15,15 @@
     <AssemblyVersion>2.1.0.0</AssemblyVersion>
     <FileVersion>2.1.0.0</FileVersion>
     <Version>2.1.0</Version>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
+  </ItemGroup>
+
 
   <ItemGroup>
     <PackageReference Include="AccidentalFish.DependencyResolver" Version="1.0.0" />

--- a/Source/AccidentalFish.Foundations.Resources.Sql/AccidentalFish.Foundations.Resources.Sql.csproj
+++ b/Source/AccidentalFish.Foundations.Resources.Sql/AccidentalFish.Foundations.Resources.Sql.csproj
@@ -14,7 +14,15 @@
     <PackageProjectUrl>https://github.com/JamesRandall/AccidentalFish.Foundations</PackageProjectUrl>
     <RepositoryUrl>https://github.com/JamesRandall/AccidentalFish.Foundations.git</RepositoryUrl>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
+  </ItemGroup>
+
 
   <ItemGroup>
     <PackageReference Include="AccidentalFish.DependencyResolver" Version="1.0.0" />

--- a/Source/AccidentalFish.Foundations.Runtime.HostableComponents/AccidentalFish.Foundations.Runtime.HostableComponents.csproj
+++ b/Source/AccidentalFish.Foundations.Runtime.HostableComponents/AccidentalFish.Foundations.Runtime.HostableComponents.csproj
@@ -14,7 +14,15 @@
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
     <PackageRequireLicenseAcceptance>True</PackageRequireLicenseAcceptance>
     <Version>2.0.0</Version>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
+  </ItemGroup>
+
 
   <ItemGroup>
     <PackageReference Include="AccidentalFish.DependencyResolver" Version="1.0.0" />

--- a/Source/AccidentalFish.Foundations.Runtime/AccidentalFish.Foundations.Runtime.csproj
+++ b/Source/AccidentalFish.Foundations.Runtime/AccidentalFish.Foundations.Runtime.csproj
@@ -15,7 +15,15 @@
     <Version>2.0.0</Version>
     <AssemblyVersion>2.0.0.0</AssemblyVersion>
     <FileVersion>2.0.0.0</FileVersion>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
+  </ItemGroup>
+
 
   <ItemGroup>
     <PackageReference Include="AccidentalFish.DependencyResolver" Version="1.0.0" />

--- a/Source/AccidentalFish.Foundations.Threading/AccidentalFish.Foundations.Threading.csproj
+++ b/Source/AccidentalFish.Foundations.Threading/AccidentalFish.Foundations.Threading.csproj
@@ -15,7 +15,15 @@
     <Version>2.0.0</Version>
     <AssemblyVersion>2.0.0.0</AssemblyVersion>
     <FileVersion>2.0.0.0</FileVersion>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
+  </ItemGroup>
+
 
   <ItemGroup>
     <PackageReference Include="AccidentalFish.DependencyResolver" Version="1.0.0" />


### PR DESCRIPTION
CSProj files have been updated to enable SourceLink in your nuget
---

*[This pull request was created with an automated workflow]*

I noticed that your repository and Nuget package are important for our .NET community, but you still haven't enabled SourceLink.

**We have to take 2 steps:**
1) Please approve this pull request and make .NET a better place for .NET developers and their debugging.
2) **Then just upload the .snupkg file** to https://www.nuget.org/ (now you can find the snupkg file along with the .nuget file)

You can find more information about SourceLine at the following links  
https://github.com/dotnet/sourcelink
https://www.hanselman.com/blog/ExploringNETCoresSourceLinkSteppingIntoTheSourceCodeOfNuGetPackagesYouDontOwn.aspx

If you are interesting about this automated workflow and how it works  
https://github.com/JTOne123/GitHubMassUpdater

*If you notice any flaws, please comment and I will try to make fixes manually*
